### PR TITLE
security: bump urllib3 to >=2.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dev = [
     "simple-term-menu>=1.6.6",
 ]
 
+[tool.uv]
+constraint-dependencies = ["urllib3>=2.7.0"]
+
 [tool.ruff]
 line-length = 120
 lint.extend-select = ["I", "UP", "PL"]

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[manifest]
+constraints = [{ name = "urllib3", specifier = ">=2.7.0" }]
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -1151,11 +1154,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump urllib3 to 2.7.0 (fixes decompression-bomb safeguard bypass in streaming API, CVE range >=2.6.0,<2.7.0)
- Add durable minimum version constraint so future lock resolves cannot regress to vulnerable 2.6.x

## Test plan
- [x] Lockfile resolves urllib3 2.7.0
- [ ] CI passes

Made with [Cursor](https://cursor.com)